### PR TITLE
Bump gitsummary to v0.3.5, require python >=3.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gitsummary" %}
-{% set version = "0.2" %}
+{% set version = "0.3.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gitsummary-{{ version }}.tar.gz
-  sha256: d37a5fc0a2d9dd1a09929d22031641ccd178c36c912c8acb19cc625b0f4ef0ad
+  sha256: f8291f8895c777e06fb6e846fc65247b7302c79e44c9a2c6b5e0ee15aea15fa2
 
 build:
   noarch: python
@@ -17,10 +17,10 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.9
+    - python >=3.10
   run:
     - gitpython
-    - python >=3.9
+    - python >=3.10
 
 test:
   imports:


### PR DESCRIPTION
Updated version to 0.3.5, updated sha256 to match the new PyPI tarball, and raised the minimum Python requirement from 3.9 to 3.10 in both host and run dependencies.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
